### PR TITLE
Skeleton modified: compliler up to 11v. in pom.xml

### DIFF
--- a/WorkAndFun/pom.xml
+++ b/WorkAndFun/pom.xml
@@ -14,8 +14,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Zmieniłem wersję compiler-a w Maven (plik pom.xml) - wcześniej ustawiło na 1.7. Teraz podniosłem do 11. Prośba by każdy sobie zmergował tę zmianę.